### PR TITLE
Separate layouts & bug showing req.user object

### DIFF
--- a/app/actions/UserActions.js
+++ b/app/actions/UserActions.js
@@ -11,19 +11,22 @@ class UserActions {
 
   manuallogin(data) {
     this.dispatch();
-    UserWebAPIUtils.manuallogin(data)
+
+    let { email, password, router } = data;
+
+    UserWebAPIUtils.manuallogin({email: email, password: password})
       .then((response, textStatus) => {
         if (textStatus === 'success') {
           // Dispatch another event for successful login
-          this.actions.loginsuccess(data.email);
+          this.actions.loginsuccess(router);
         }
       }, () => {
         // Dispatch another event for a bad login
       });
   }
 
-  loginsuccess(email) {
-    this.dispatch(email);
+  loginsuccess(router) {
+    this.dispatch(router);
   }
 
   // Leaving this here for future use

--- a/app/components/Login.jsx
+++ b/app/components/Login.jsx
@@ -36,7 +36,8 @@ export default class Login extends React.Component {
     const password = React.findDOMNode(this.refs.password).value;
     UserActions.manuallogin({
       email: email,
-      password: password
+      password: password,
+      router: this.context.router
     });
   }
 
@@ -74,3 +75,4 @@ export default class Login extends React.Component {
 }
 
 Login.propTypes = { user: React.PropTypes.instanceOf(Immutable.Map) };
+Login.contextTypes = { router: React.PropTypes.object };

--- a/app/components/Navigation.jsx
+++ b/app/components/Navigation.jsx
@@ -47,6 +47,7 @@ export default class Navigation extends React.Component {
           )}
           <Link className={styles.navigation__item} to="/dashboard">Dashboard</Link>
           <Link to="/about" className={styles.navigation__item} activeClassName={styles['navigation__item--active']}>About</Link>
+          <a>{this.state.user.get('email')}</a>
       </nav>
     );
   }

--- a/app/components/UnauthorisedApp.jsx
+++ b/app/components/UnauthorisedApp.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import 'scss/main';
+
+export default class UnauthorisedApp extends React.Component {
+  render() {
+    return (
+      <div>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+UnauthorisedApp.propTypes = { children: React.PropTypes.object };

--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -7,6 +7,7 @@ import About from 'components/About';
 import Login from 'components/Login';
 import Logout from 'components/Logout';
 import Dashboard from 'components/Dashboard';
+import UnauthorisedApp from 'components/UnauthorisedApp';
 
 import UserStore from 'stores/UserStore';
 
@@ -17,11 +18,18 @@ function requireAuth(nextState, transition) {
 }
 
 export default (
-  <Route component={App}>
-    <Route path="/" component={Vote} />
-    <Route path="login" component={Login} />
-    <Route path="logout" component={Logout} />
-    <Route path="dashboard" component={Dashboard} onEnter={requireAuth} />
-    <Route path="about" component={About} />
+  <Route>
+    <Route component={App}>
+      <Route path="/" component={Vote} />
+      <Route path="logout" component={Logout} />
+      <Route path="dashboard" component={Dashboard} onEnter={requireAuth} />
+      <Route path="about" component={About} />
+    </Route>
+
+    <Route component={UnauthorisedApp}>
+      <Route path="login" component={Login} />
+    </Route>
+
+
   </Route>
 );

--- a/app/stores/UserStore.js
+++ b/app/stores/UserStore.js
@@ -63,9 +63,11 @@ class UserStore {
     this.emitChange();
   }
 
-  handleLoginSuccess() {
+  handleLoginSuccess(router) {
     this.user = this.user.merge({ isWaiting: false, authenticated: true });
     this.emitChange();
+
+    router.replaceWith('/dashboard'); // This needs to be made dynamic
   }
 
   handleLogoutAttempt() {

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -20,7 +20,7 @@ module.exports = function(app, passport) {
   // Redirect the user to Google for authentication. When complete, Google
   // will redirect the user back to the application at
   // /auth/google/return
-  // Authentication with google requires an additional scope param, for more info go 
+  // Authentication with google requires an additional scope param, for more info go
   // here https://developers.google.com/identity/protocols/OpenIDConnect#scope-param
   app.get('/auth/google', passport.authenticate('google', { scope: [
         'https://www.googleapis.com/auth/userinfo.profile',
@@ -59,7 +59,7 @@ module.exports = function(app, passport) {
       if(!err) {
         var topicmap = _.indexBy(topics, 'id');
         // We don't want to be seeding and generating markup with user information
-        var user = req.user ? { authenticated: true, isWaiting: false } : { authenticated: false, isWaiting: false };
+        var user = req.user ? { authenticated: true, isWaiting: false, email: req.user.email } : { authenticated: false, isWaiting: false };
         // An object that contains response local variables scoped to the request, and therefore available only to the view(s) rendered during
         // that request/response cycle (if any). Otherwise, this property is identical to app.locals
         // This property is useful for exposing request-level information such as request path name, authenticated user, user settings, and so on.


### PR DESCRIPTION
# Related Issues

#56 #57 #58 

This PR shows two things

1) The ability to split the login route into a different 'layout' - this will allow theming etc.
2) An example showing the issues stated in issue #57 - Once you login you will be auto redirected to the dashboard (https://github.com/choonkending/react-webpack-node/compare/master...joshhornby:feature/layout?expand=1#diff-129f1ad504e80d839c390c823d8ad3c2R70) You will notice you should see the users email in the nav bar (https://github.com/choonkending/react-webpack-node/compare/master...joshhornby:feature/layout?expand=1#diff-129f1ad504e80d839c390c823d8ad3c2R70) - this has been added to the `user` object in the server routes file (https://github.com/choonkending/react-webpack-node/compare/master...joshhornby:feature/layout?expand=1#diff-99de27cb2ded592bf6ae68b3d132eaceR62) But the email is only shown AFTER a refresh of the page - this is because after the redirect the user state only contains the following 

`Object {authenticated: true, isWaiting: false}`

Which is set here https://github.com/choonkending/react-webpack-node/compare/master...joshhornby:feature/layout?expand=1#diff-129f1ad504e80d839c390c823d8ad3c2R67

# Todos

- [ ] I don't love the way the router is passed into the store - it just doesn't feel correct
- [ ] Make the redirect dynamic as seen in this following example - https://github.com/rackt/react-router/blob/master/examples/auth-flow/app.js#L79

@choonkending Looking forward to hearing your feedback, especially regarding point 2. This may also be related to issue #58 as that should handle the redirect for us come to think of it, but as outlined on there it doesn't always seem to be fired.