### PR TITLE
Fixed broken webpack config link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Boilerplate for React application with webpack using alt's Flux running on a nod
  - [react-router](https://github.com/rackt/react-router)
 2. Stores storing data using [ImmutableJS](https://github.com/facebook/immutable-js) data structures
 3. [Css Modules](https://github.com/webpack/css-loader#css-modules)
-4. Webpack [config file](https://github.com/choonkending/react-webpack-node/blob/master/webpack.config.js)
+4. Webpack [config file](https://github.com/choonkending/react-webpack-node/blob/master/webpack/webpack.config.js)
 5. Express server
 6. Mongoose for MongoDB
 7. Procfile to enable deployment to Heroku.


### PR DESCRIPTION
Noticed this trying to click from the npm site. Link to webpack config file is broken.