### PR TITLE
res.send() depricated and update css-loader

### DIFF
--- a/app/server.jsx
+++ b/app/server.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import { RoutingContext, match } from 'react-router'
+import { RoutingContext, match } from 'react-router';
 import createLocation from 'history/lib/createLocation';
 import Iso from 'iso';
 
@@ -15,19 +15,20 @@ import html from 'base.html';
  * @param {Object} req passed from Express/Koa server
  */
 const renderToMarkup = (alt, state, req, res) => {
-  let markup, content;
+  let markup;
   let location = new createLocation(req.url);
   alt.bootstrap(state);
   match({ routes, location }, (error, redirectLocation, renderProps) => {
-    if (redirectLocation)
-      res.redirect(301, redirectLocation.pathname + redirectLocation.search)
-    else if (error)
-      res.send(500, error.message)
-    else if (renderProps == null)
-      res.send(404, 'Not found')
-    else
-      content = ReactDOMServer.renderToString(<RoutingContext {...renderProps} />);
+    if (error) {
+      res.status(500).send(error.message);
+    } else if (redirectLocation) {
+      res.redirect(301, redirectLocation.pathname + redirectLocation.search);
+    } else if (renderProps) {
+      let content = ReactDOMServer.renderToString(<RoutingContext {...renderProps} />);
       markup = Iso.render(content, alt.flush());
+    } else {
+      res.status(404).send('Not found');
+    }
   });
 
   return markup;

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react": "^0.14.2",
     "react-dom": "^0.14.2",
     "react-helmet": "^1.0.1",
-    "react-router": "1.0.0-rc1",
+    "react-router": "1.0.0",
     "sass-loader": "^1.0.2",
     "style-loader": "^0.12.3",
     "url-loader": "^0.5.6",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "connect-mongo": "^0.8.1",
     "cookie-parser": "^1.3.3",
     "cookie-session": "^1.1.0",
-    "css-loader": "^0.16.0",
+    "css-loader": "^0.22.0",
     "eslint": "^0.22.1",
     "eslint-loader": "^0.12.0",
     "eslint-plugin-react": "^2.5.0",


### PR DESCRIPTION
- res.send(status, body) is deprecated. Change to res.status().send() instead.
- update css-loader to avoid deprecated options.
- react-router 1.0.0 is released