### PR TITLE
Remove webpack --progress from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf public",
     "start": "NODE_ENV=production node server/index.js",
     "dev": "NODE_ENV=development node server/index.js",
-    "build:webpack": "NODE_ENV=production webpack --progress --colors --config ./webpack/webpack.config.prod.js",
+    "build:webpack": "NODE_ENV=production webpack --colors --config ./webpack/webpack.config.prod.js",
     "build": "npm run clean && npm run build:webpack",
     "test": "NODE_ENV=test karma start",
     "test:watch": "NODE_ENV=test npm test -- --watch --no-single-run",


### PR DESCRIPTION
Been seeing random failures when deploying to Heroku and it turns out [--progress breaks deployment on Heroku](https://github.com/webpack/webpack/issues/1553)

`--progress` was recently removed from the react-boilerplate project for the same reason: https://github.com/mxstbr/react-boilerplate/pull/176