### PR TITLE
fix duplicate fetch in WrappedComponent.need

### DIFF
--- a/app/api/fetchComponentDataBeforeRender.js
+++ b/app/api/fetchComponentDataBeforeRender.js
@@ -7,7 +7,6 @@
 export function fetchComponentDataBeforeRender(dispatch, components, params) {
   const needs = components.reduce((prev, current) => {
     return (current.need || [])
-      .concat((current.WrappedComponent ? current.WrappedComponent.need : []) || [])
       .concat(prev);
     }, []);
     const promises = needs.map(need => dispatch(need(params)));


### PR DESCRIPTION
fix #166.

In ES6, `static` properties are the class' own properties. So

```javascript
class Vote extends Component {

  static need = [  // eslint-disable-line
    fetchTopics
  ];
 ...
}
```
is transpiled into this by babel

```javascript
function Vote() {}
...
Vote.need = [fetchTopics];
```

And in `react-redux` source code, `connect` returns `hoistStatics(Connect, WrappedComponent)`, which merges WrappedComponent's own properties into Connect. So `current.need` is identical with `current.WrappedComponent.need`.