### PR TITLE
Feat/code cleanup

### DIFF
--- a/app/containers/LoginOrRegister.jsx
+++ b/app/containers/LoginOrRegister.jsx
@@ -16,36 +16,25 @@ class LoginOrRegister extends Component {
    */
   constructor(props) {
     super(props);
-    this.toggleMode = this.toggleMode.bind(this);
     this.handleOnSubmit = this.handleOnSubmit.bind(this);
   }
 
   handleOnSubmit(event) {
     event.preventDefault();
 
-    const { dispatch, user: { isLogin } } = this.props;
+    const { manualLogin, signUp, user: { isLogin } } = this.props;
     const email = ReactDOM.findDOMNode(this.refs.email).value;
     const password = ReactDOM.findDOMNode(this.refs.password).value;
 
     if (isLogin) {
-      dispatch(manualLogin({
-        email,
-        password
-      }));
+      manualLogin({ email, password });
     } else {
-      dispatch(signUp({
-        email,
-        password
-      }));
+      signUp({ email, password });
     }
   }
 
-  toggleMode() {
-    this.props.dispatch(toggleLoginMode());
-  }
-
   renderHeader() {
-    const { isLogin } = this.props.user;
+    const { user: { isLogin } , toggleLoginMode } = this.props;
     if (isLogin) {
       return (
         <div className={cx('header')}>
@@ -53,7 +42,7 @@ class LoginOrRegister extends Component {
           <div className={cx('alternative')}>
             Not what you want?
             <a className={cx('alternative-link')}
-              onClick={this.toggleMode}> Register an Account</a>
+              onClick={toggleLoginMode}> Register an Account</a>
           </div>
         </div>
       );
@@ -65,7 +54,7 @@ class LoginOrRegister extends Component {
         <div className={cx('alternative')}>
           Already have an account?
           <a className={cx('alternative-link')}
-            onClick={this.toggleMode}> Login</a>
+            onClick={toggleLoginMode}> Login</a>
         </div>
       </div>
     );
@@ -116,18 +105,21 @@ class LoginOrRegister extends Component {
 
 LoginOrRegister.propTypes = {
   user: PropTypes.object,
-  dispatch: PropTypes.func
+  manualLogin: PropTypes.func.isRequired,
+  signUp: PropTypes.func.isRequired,
+  toggleLoginMode: PropTypes.func.isRequired
 };
 
 // Function passed in to `connect` to subscribe to Redux store updates.
 // Any time it updates, mapStateToProps is called.
-function mapStateToProps(state) {
+function mapStateToProps({user}) {
   return {
-    user: state.user
+    user
   };
 }
 
 // Connects React component to the redux store
 // It does not modify the component class passed to it
 // Instead, it returns a new, connected component class, for you to use.
-export default connect(mapStateToProps)(LoginOrRegister);
+export default connect(mapStateToProps, { manualLogin, signUp, toggleLoginMode })(LoginOrRegister);
+

--- a/app/containers/Message.jsx
+++ b/app/containers/Message.jsx
@@ -6,37 +6,21 @@ import styles from 'css/components/message';
 
 const cx = classNames.bind(styles);
 
-class Message extends Component {
-  constructor(props) {
-    super(props);
-
-    this.onDismiss = this.onDismiss.bind(this);
-  }
-
-  onDismiss() {
-    this.props.dispatch(dismissMessage());
-  }
-
-  render() {
-    const {message, type} = this.props;
-
-    return (
-      <div className={cx('message', {
-        show: message && message.length > 0,
-        success: type === 'SUCCESS'
-      })} onClick={this.onDismiss}>{message}</div>
-    );
-  }
-}
+const Message = ({message, type, dismissMessage}) => (
+    <div className={cx('message', {
+      show: message && message.length > 0,
+      success: type === 'SUCCESS'
+    })} onClick={dismissMessage}>{message}</div>
+);
 
 Message.propTypes = {
   message: PropTypes.string,
   type: PropTypes.string,
-  dispatch: PropTypes.func.isRequired
+  dismissMessage: PropTypes.func.isRequired
 };
 
 function mapStateToProps(state) {
   return {...state.message};
 }
 
-export default connect(mapStateToProps)(Message);
+export default connect(mapStateToProps, { dismissMessage })(Message);

--- a/app/containers/Navigation.jsx
+++ b/app/containers/Navigation.jsx
@@ -8,16 +8,14 @@ import styles from 'css/components/navigation';
 
 const cx = classNames.bind(styles);
 
-const Navigation = ({user, dispatch}) => {
-	const logout = () => dispatch(logOut());
-
+const Navigation = ({ user, logOut }) => {
     return (
       <nav className={cx('navigation')} role="navigation">
         <Link to="/"
           className={cx('item', 'logo')}
           activeClassName={cx('active')}>Ninja Ocean</Link>
           { user.authenticated ? (
-            <Link onClick={logout}
+            <Link onClick={logOut}
               className={cx('item')} to="/">Logout</Link>
           ) : (
             <Link className={cx('item')} to="/login">Log in</Link>
@@ -30,7 +28,7 @@ const Navigation = ({user, dispatch}) => {
 
 Navigation.propTypes = {
   user: PropTypes.object,
-  dispatch: PropTypes.func.isRequired
+  logOut: PropTypes.func.isRequired
 };
 
 function mapStateToProps(state) {
@@ -39,4 +37,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(Navigation);
+export default connect(mapStateToProps, { logOut })(Navigation);

--- a/app/containers/Vote.jsx
+++ b/app/containers/Vote.jsx
@@ -4,8 +4,7 @@ import classNames from 'classnames/bind';
 import EntryBox from 'components/EntryBox';
 import MainSection from 'components/MainSection';
 import Scoreboard from 'components/Scoreboard';
-import {
-  createTopic, typing, incrementCount,
+import { createTopic, typing, incrementCount,
   decrementCount, destroyTopic, fetchTopics } from 'actions/topics';
 import styles from 'css/components/vote';
 
@@ -19,54 +18,17 @@ class Vote extends Component {
     fetchTopics
   ]
 
-  constructor(props) {
-    super(props);
-    // event handlers for MainSection component
-    this.onIncrement = this.onIncrement.bind(this);
-    this.onDecrement = this.onDecrement.bind(this);
-    this.onDestroy = this.onDestroy.bind(this);
-    // event handlers for EntryBox component
-    this.onEntryChange = this.onEntryChange.bind(this);
-    this.onEntrySave = this.onEntrySave.bind(this);
-  }
-
-  onIncrement(id, index) {
-    const { dispatch } = this.props;
-    dispatch(incrementCount(id, index));
-  }
-
-  onDecrement(id, index) {
-    const { dispatch } = this.props;
-    dispatch(decrementCount(id, index));
-  }
-
-  onDestroy(id, index) {
-    const { dispatch } = this.props;
-    dispatch(destroyTopic(id, index));
-  }
-
-  onEntryChange(text) {
-    const { dispatch } = this.props;
-    dispatch(typing(text));
-  }
-
-  onEntrySave(text) {
-    const { dispatch } = this.props;
-    dispatch(createTopic(text));
-  }
-
-
   render() {
-    const {newTopic, topics} = this.props;
+    const {newTopic, topics, typing, createTopic, destroyTopic, incrementCount, decrementCount } = this.props;
     return (
       <div className={cx('vote')}>
         <EntryBox topic={newTopic}
-          onEntryChange={this.onEntryChange}
-          onEntrySave={this.onEntrySave} />
+          onEntryChange={typing}
+          onEntrySave={createTopic} />
         <MainSection topics={topics}
-          onIncrement={this.onIncrement}
-          onDecrement={this.onDecrement}
-          onDestroy={this.onDestroy} />
+          onIncrement={incrementCount}
+          onDecrement={decrementCount}
+          onDestroy={destroyTopic} />
         <Scoreboard topics={topics} />
       </div>
     );
@@ -75,8 +37,12 @@ class Vote extends Component {
 
 Vote.propTypes = {
   topics: PropTypes.array.isRequired,
-  newTopic: PropTypes.string,
-  dispatch: PropTypes.func.isRequired
+  typing: PropTypes.func.isRequired,
+  createTopic: PropTypes.func.isRequired,
+  destroyTopic: PropTypes.func.isRequired,
+  incrementCount: PropTypes.func.isRequired,
+  decrementCount: PropTypes.func.isRequired,
+  newTopic: PropTypes.string
 };
 
 function mapStateToProps(state) {
@@ -88,4 +54,4 @@ function mapStateToProps(state) {
 
 // Read more about where to place `connect` here:
 // https://github.com/rackt/react-redux/issues/75#issuecomment-135436563
-export default connect(mapStateToProps)(Vote);
+export default connect(mapStateToProps, { createTopic, typing, incrementCount, decrementCount, destroyTopic })(Vote);

--- a/docs/Redux.md
+++ b/docs/Redux.md
@@ -1,0 +1,99 @@
+# Redux with React
+
+There are a million good resources out there for learning Redux.
+If you want to learn more, just go to the [docs](http://redux.js.org/).
+Trust me, it's good. Otherwise, read the code yourself!
+
+This README is here is to explain some of the syntax we opted to use.
+
+We recently switched to using `mapDispatchToProps` in our react-redux `connect`
+function. This is an implementation detail, but I hope the explanation below
+provides a bit more clarity if you are confused.
+
+
+**connect([mapStateToProps], [mapDispatchToProps], [mergeProps], [options])**
+
+Examples out in the wild typically only maps State to props, and expect a
+`dispatch` prop to be passed into the component.
+
+```javascript
+import { someAction } from 'actions';
+
+class Life extends React.Component {
+  constructor(props) {
+    super(props);
+    this.doSomething = this.doSomething.bind(this);
+  }
+
+  doSomething() {
+    this.props.dispatch(someAction());
+  }
+
+  render() {
+    return (<div onClick={this.doSomething}>{this.props.todos}</div>
+  }
+}
+
+function mapStateToProps(state) {
+  return { todos: state.todos };
+}
+
+export default connect(mapStateToProps)(Life);
+```
+
+It makes sense and gives clarity to what the Container component is doing.
+However, we've found that using mapDispatchToProps is a better way forward
+because:
+- It takes away the `redux` implementation away from this component. It becomes a
+  simple component that only expects `func` as props when an action is triggered.
+
+The example below will illustrate what I mean:
+
+
+```javascript
+import { someAction } from 'actions';
+
+class Life extends React.Component {
+
+  render() {
+    return (<div onClick={this.props.someAction}>{this.props.todos}</div>
+  }
+}
+
+function mapStateToProps(state) {
+  return { todos: state.todos };
+}
+
+export default connect(mapStateToProps, { someAction })(Life);
+```
+
+Read more
+[here](https://github.com/reactjs/react-redux/blob/master/docs/api.md#inject-todos-and-all-action-creators) to understand.
+
+Alternatively, you can write a `mapDispatchToProps` function if you wish to make
+your code more readable.
+
+```javascript
+
+import { someAction } from 'actions';
+
+class Life extends React.Component {
+
+  render() {
+    return (<div onClick={this.props.someAction}>{this.props.todos}</div>
+  }
+}
+
+function mapStateToProps(state) {
+  return { todos: state.todos };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    someAction: () => dispatch(someAction)
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Life);
+```
+


### PR DESCRIPTION
# Changes
**Related to** https://github.com/choonkending/react-webpack-node/issues/220

Begin using `mapDispatchToProps`. Read `docs/Redux.md` for the explanation.

**Pros**
- `mapDispatchToProps` wraps our action creators with a dispatch, so the component with action handlers will just call the `action` as a `prop` without having to `dispatch(action())`