### PR TITLE
Added height: 100% to #app div

### DIFF
--- a/app/server.jsx
+++ b/app/server.jsx
@@ -85,7 +85,7 @@ export default function render(req, res) {
               ${header.link.toString()}
             </head>
             <body>
-              <div id="app">${componentHTML}</div>
+              <div id="app" style="height: 100%">${componentHTML}</div>
               <script>window.__INITIAL_STATE__ = ${JSON.stringify(initialState)};</script>
               <script type="text/javascript" charset="utf-8" src="/assets/app.js"></script>
             </body>


### PR DESCRIPTION
In case if users want to use fullscreen background or videos html and body will be set 100% height, #app needs to reflect this. This practice is used in various other react starters :)