### PR TITLE
Async and Reducer Tests

### DIFF
--- a/app/actions/topics.js
+++ b/app/actions/topics.js
@@ -132,40 +132,31 @@ export function fetchTopics() {
 
 export function incrementCount(id, index) {
   return dispatch => {
-    dispatch(increment(index));
-
     return makeTopicRequest('put', id, {
         isFull: false,
         isIncrement: true
-      });
-    // do something with the ajax response
-    // You can also dispatch here
-    // E.g.
-    // .then(response => {});
+      })
+      .then(() => dispatch(increment(index)))
+      .catch(() => dispatch(createTopicFailure({id, error: 'Oops! Something went wrong and we couldn\'t add your vote'})));
   };
 }
 
 export function decrementCount(id, index) {
   return dispatch => {
-    dispatch(decrement(index));
     return makeTopicRequest('put', id, {
         isFull: false,
         isIncrement: false
-      });
-    // do something with the ajax response
-    // You can also dispatch here
-    // E.g.
-    // .then(response => {});
+      })
+      .then(() => dispatch(decrement(index)))
+      .catch(() => dispatch(createTopicFailure({id, error: 'Oops! Something went wrong and we couldn\'t add your vote'})));
   };
 }
 
 export function destroyTopic(id, index) {
   return dispatch => {
-    dispatch(destroy(index));
-    return makeTopicRequest('delete', id);
-    // do something with the ajax response
-    // You can also dispatch here
-    // E.g.
-    // .then(response => {});
+    return makeTopicRequest('delete', id)
+      .then(() => dispatch(destroy(index)))
+      .catch(() => dispatch(createTopicFailure({id,
+        error: 'Oops! Something went wrong and we couldn\'t add your vote'})));
   };
 }

--- a/app/actions/topics.js
+++ b/app/actions/topics.js
@@ -17,19 +17,19 @@ polyfill();
  * @param String endpoint
  * @return Promise
  */
-function makeTopicRequest(method, id, data, api = '/topic') {
+export function makeTopicRequest(method, id, data, api = '/topic') {
   return request[method](api + (id ? ('/' + id) : ''), data);
 }
 
-function increment(index) {
+export function increment(index) {
   return { type: types.INCREMENT_COUNT, index };
 }
 
-function decrement(index) {
+export function decrement(index) {
   return { type: types.DECREMENT_COUNT, index };
 }
 
-function destroy(index) {
+export function destroy(index) {
   return { type: types.DESTROY_TOPIC, index };
 }
 
@@ -45,7 +45,7 @@ export function typing(text) {
  * @param data
  * @return a simple JS object
  */
-function createTopicRequest(data) {
+export function createTopicRequest(data) {
   return {
     type: types.CREATE_TOPIC_REQUEST,
     id: data.id,
@@ -54,13 +54,13 @@ function createTopicRequest(data) {
   };
 }
 
-function createTopicSuccess() {
+export function createTopicSuccess() {
   return {
     type: types.CREATE_TOPIC_SUCCESS
   };
 }
 
-function createTopicFailure(data) {
+export function createTopicFailure(data) {
   return {
     type: types.CREATE_TOPIC_FAILURE,
     id: data.id,
@@ -68,7 +68,7 @@ function createTopicFailure(data) {
   };
 }
 
-function createTopicDuplicate() {
+export function createTopicDuplicate() {
   return {
     type: types.CREATE_TOPIC_DUPLICATE
   };

--- a/app/reducers/topic.js
+++ b/app/reducers/topic.js
@@ -30,7 +30,8 @@ export default function topic(state = {
       });
     case GET_TOPICS_FAILURE:
       return Object.assign({}, state, {
-        isFetching: false
+        isFetching: false,
+        error: action.error
       });
     case CREATE_TOPIC_REQUEST:
       return {

--- a/app/tests/actions/topics-test.js
+++ b/app/tests/actions/topics-test.js
@@ -16,6 +16,22 @@ const mockStore = configureStore(middlewares);
 describe('Topic Actions', () => {
   describe('Asynchronous actions', () => {
     let sandbox;
+
+    const topic = 'A time machine';
+    const id = md5.hash(topic);
+    const data = {
+      id,
+      count: 1,
+      text: topic
+    };
+
+    const initialState = {
+      topic: {
+        topics: [],
+        newtopic: ''
+      }
+    };
+
     beforeEach(() => {
       sandbox = sinon.sandbox.create(); // eslint-disable-line
     });
@@ -25,21 +41,6 @@ describe('Topic Actions', () => {
     });
 
     it('dispatches request and success actions when status is 200', done => {
-      const topic = 'A time machine';
-      const id = md5.hash(topic);
-      const data = {
-        id,
-        count: 1,
-        text: topic
-      };
-
-      const initialState = {
-        topic: {
-          topics: [],
-          newtopic: ''
-        }
-      };
-
       const expectedActions = [
         {
           type: types.CREATE_TOPIC_REQUEST,
@@ -62,21 +63,6 @@ describe('Topic Actions', () => {
     });
 
     it('dispatches request and failed actions when status is NOT 200', done => {
-      const topic = 'A time machine';
-      const id = md5.hash(topic);
-      const data = {
-        id,
-        count: 1,
-        text: topic
-      };
-
-      const initialState = {
-        topic: {
-          topics: [],
-          newtopic: ''
-        }
-      };
-
       const expectedActions = [
         {
           type: types.CREATE_TOPIC_REQUEST,
@@ -100,22 +86,7 @@ describe('Topic Actions', () => {
     });
 
     it('dispatches a duplicate action for a duplicate topic', () => {
-      const topic = 'A time machine';
-      const id = md5.hash(topic);
-      const data = {
-        id,
-        count: 1,
-        text: topic
-      };
-
-      const initialState = {
-        topic: {
-          topics: [
-            data
-          ],
-          newtopic: ''
-        }
-      };
+      initialState.topic.topics.push(data);
 
       const expectedActions = [
         {
@@ -126,6 +97,104 @@ describe('Topic Actions', () => {
       const store = mockStore(initialState);
       store.dispatch(actions.createTopic(topic));
       expect(store.getActions()).toEqual(expectedActions);
+      initialState.topic.topics.pop();
     });
   });
- });
+  describe('Action creator unit tests', () => {
+    const index = 0;
+    const topic = 'A time machine';
+    const id = md5.hash(topic);
+    const data = {
+      id,
+      count: 1,
+      text: topic
+    };
+    let sandbox;
+
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create(); // eslint-disable-line
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should create an action object to increment the count', () => {
+      const expectedAction = {
+        type: types.INCREMENT_COUNT,
+        index
+      };
+      expect(actions.increment(index)).toEqual(expectedAction);
+    });
+
+    it('should create an action object to decrement count', () => {
+      const expectedAction = {
+        type: types.DECREMENT_COUNT,
+        index
+      };
+      expect(actions.decrement(index)).toEqual(expectedAction);
+    });
+
+    it('should create an action object to destroy a topic', () => {
+      const expectedAction = {
+        type: types.DESTROY_TOPIC,
+        index
+      };
+      expect(actions.destroy(index)).toEqual(expectedAction);
+    });
+
+    it('should create an action object with a new topic', () => {
+      const expectedAction = {
+        type: types.TYPING,
+        newTopic: data.text
+      };
+      expect(actions.typing(data.text)).toEqual(expectedAction);
+    });
+
+    it('should create an action object with a new topic request', () => {
+      const expectedAction = {
+        type: types.CREATE_TOPIC_REQUEST,
+        id: data.id,
+        count: data.count,
+        text: data.text
+      };
+      expect(actions.createTopicRequest(data)).toEqual(expectedAction);
+    });
+
+    it('should create an action object on a new topic success', () => {
+      const expectedAction = {
+        type: types.CREATE_TOPIC_SUCCESS
+      };
+      expect(actions.createTopicSuccess()).toEqual(expectedAction);
+    });
+
+    it('should create an action object on a new topic failure', () => {
+      const dataFail = Object.assign({}, {
+        error: 'Oops! Something went wrong and we couldn\'t create your topic',
+        id: data.id
+      });
+      const expectedAction = {
+        type: types.CREATE_TOPIC_FAILURE,
+        id: dataFail.id,
+        error: dataFail.error
+      };
+      expect(actions.createTopicFailure(dataFail)).toEqual(expectedAction);
+    });
+
+    it('should create an action on a topic duplicate', () => {
+      const expectedAction = {
+        type: types.CREATE_TOPIC_DUPLICATE
+      };
+      expect(actions.createTopicDuplicate()).toEqual(expectedAction);
+    });
+
+    it('should create an action when fetching topics', () => {
+      sandbox.stub(axios, 'get').returns('hello');
+      const expectedAction = {
+        type: types.GET_TOPICS,
+        promise: 'hello'
+      };
+      expect(actions.fetchTopics()).toEqual(expectedAction);
+    });
+  });
+});

--- a/app/tests/actions/topics-test.js
+++ b/app/tests/actions/topics-test.js
@@ -17,6 +17,7 @@ describe('Topic Actions', () => {
   describe('Asynchronous actions', () => {
     let sandbox;
 
+    const index = 0;
     const topic = 'A time machine';
     const id = md5.hash(topic);
     const data = {
@@ -40,7 +41,7 @@ describe('Topic Actions', () => {
       sandbox.restore();
     });
 
-    it('dispatches request and success actions when status is 200', done => {
+    it('createTopic dispatches request and success actions when status is 200', done => {
       const expectedActions = [
         {
           type: types.CREATE_TOPIC_REQUEST,
@@ -58,11 +59,10 @@ describe('Topic Actions', () => {
       store.dispatch(actions.createTopic(topic))
         .then(() => {
           expect(store.getActions()).toEqual(expectedActions);
-        })
-        .then(done).catch(done);
+        }).then(done).catch(done);
     });
 
-    it('dispatches request and failed actions when status is NOT 200', done => {
+    it('createTopic dispatches request and failed actions when status is NOT 200', done => {
       const expectedActions = [
         {
           type: types.CREATE_TOPIC_REQUEST,
@@ -81,11 +81,10 @@ describe('Topic Actions', () => {
       store.dispatch(actions.createTopic(topic))
         .then(() => {
           expect(store.getActions()).toEqual(expectedActions);
-        })
-        .then(done).catch(done);
+        }).then(done).catch(done);
     });
 
-    it('dispatches a duplicate action for a duplicate topic', () => {
+    it('createTopic dispatches a duplicate action for a duplicate topic', () => {
       initialState.topic.topics.push(data);
 
       const expectedActions = [
@@ -98,6 +97,93 @@ describe('Topic Actions', () => {
       store.dispatch(actions.createTopic(topic));
       expect(store.getActions()).toEqual(expectedActions);
       initialState.topic.topics.pop();
+    });
+
+    it('incrementCount dispatches an increment count action on success', done => {
+      const expectedActions = [
+      {
+        type: types.INCREMENT_COUNT,
+        index
+      }];
+      sandbox.stub(axios, 'put').returns(Promise.resolve({ status: 200 }));
+      const store = mockStore();
+      store.dispatch(actions.incrementCount(data.id, index))
+        .then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+        }).then(done).catch(done);
+    });
+
+    it('incrementCount should not dispatch a failure action on failure', done => {
+      const expectedActions = [
+      {
+        type: types.CREATE_TOPIC_FAILURE,
+        id: data.id,
+        error: 'Oops! Something went wrong and we couldn\'t add your vote'
+      }];
+      sandbox.stub(axios, 'put').returns(Promise.reject({ status: 400 }));
+      const store = mockStore();
+      store.dispatch(actions.incrementCount(data.id, index))
+        .then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+        }).then(done).catch(done);
+    });
+
+    it('decrementCount dispatches an decrement count action on success', done => {
+      const expectedActions = [
+      {
+        type: types.DECREMENT_COUNT,
+        index
+      }];
+      sandbox.stub(axios, 'put').returns(Promise.resolve({ status: 200 }));
+      const store = mockStore();
+      store.dispatch(actions.decrementCount(data.id, index))
+        .then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+        }).then(done).catch(done);
+    });
+
+    it('decrementCount should not dispatch a decrement count action on failure', done => {
+      const expectedActions = [
+      {
+        type: types.CREATE_TOPIC_FAILURE,
+        error: 'Oops! Something went wrong and we couldn\'t add your vote',
+        id: data.id
+      }];
+      sandbox.stub(axios, 'put').returns(Promise.reject({ status: 400 }));
+      const store = mockStore(initialState);
+      store.dispatch(actions.decrementCount(data.id, index))
+        .then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+        }).then(done).catch(done);
+    });
+
+    it('destroyTopic dispatches a decrement count action on success', done => {
+      const expectedActions = [
+      {
+        type: types.DESTROY_TOPIC,
+        index
+      }];
+      sandbox.stub(axios, 'delete').returns(Promise.resolve({ status: 200 }));
+      const store = mockStore();
+      store.dispatch(actions.destroyTopic(data.id, index))
+        .then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+        }).then(done).catch(done);
+    });
+
+    it('destroyTopic should not dispatch an decrement count action on failure', done => {
+      const expectedActions = [
+      {
+        type: types.CREATE_TOPIC_FAILURE,
+        id: data.id,
+        error: 'Oops! Something went wrong and we couldn\'t add your vote'
+      }];
+      sandbox.stub(axios, 'delete').returns(Promise.reject({ status: 400 }));
+      const store = mockStore();
+      store.dispatch(actions.destroyTopic(data.id, index))
+        .then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+        }).then(done).catch(done);
     });
   });
   describe('Action creator unit tests', () => {

--- a/app/tests/reducers/topic-test.js
+++ b/app/tests/reducers/topic-test.js
@@ -4,6 +4,34 @@ import reducer from 'reducers/topic';
 import * as types from 'types';
 
 describe('Topics reducer', () => {
+  const s = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
+  function createTopic() {
+    return Array(5).join().split(',').map(() => {
+      return s.charAt(Math.floor(Math.random() * s.length));
+    }).join('');
+  }
+
+  const topic = createTopic();
+
+  function createData() {
+    return {
+      text: createTopic(),
+      id: md5.hash(createTopic()),
+      count: Math.floor(Math.random() * 100)
+    };
+  }
+
+  const data = createData();
+
+  function createTopics(x) {
+    const arr = [];
+    for (let i = 0; i < x; i++) {
+      arr.push(createData());
+    }
+    return arr;
+  }
+
   it('Should return the initial state', () => {
     expect(
       reducer(undefined, {})
@@ -16,24 +44,180 @@ describe('Topics reducer', () => {
   });
 
   it('Should add a new topic to an empty initial state', () => {
-    const topic = 'A time machine';
-    const id = md5.hash(topic);
     expect(
       reducer(undefined, {
         type: types.CREATE_TOPIC_REQUEST,
-        id,
+        id: data.id,
         count: 1,
         text: topic
       })
     ).toEqual({
-      topics: [
-        {
-          id,
-          count: 1,
-          text: topic
+        topics: [
+          {
+            id: data.id,
+            count: 1,
+            text: topic
+          }
+        ],
+        newTopic: ''
+    });
+  });
+
+  it('Should handle TYPING', () => {
+    expect(
+      reducer(undefined, {
+        type: types.TYPING,
+        newTopic: topic
+      })
+    ).toEqual({
+        topics: [],
+        newTopic: topic
+    });
+  });
+
+  it('Should handle GET_TOPICS_REQUEST', () => {
+    expect(
+      reducer(undefined, {
+        type: types.GET_TOPICS_REQUEST
+      })
+    ).toEqual({
+        isFetching: true,
+        topics: [],
+        newTopic: ''
+    });
+  });
+
+  it('Should handle GET_TOPICS_SUCCESS', () => {
+    expect(
+      reducer(undefined, {
+        type: types.GET_TOPICS_SUCCESS,
+        req: {
+          data: topic
         }
-      ],
-      newTopic: ''
+      })
+    ).toEqual({
+        isFetching: false,
+        topics: topic,
+        newTopic: ''
+    });
+  });
+
+  it('Should handle GET_TOPICS_FAILURE', () => {
+    expect(
+      reducer(undefined, {
+        type: types.GET_TOPICS_FAILURE,
+        error: 'Error',
+        id: data.id
+      })
+    ).toEqual({
+        topics: [],
+        newTopic: '',
+        error: 'Error',
+        isFetching: false
+    });
+  });
+
+  it('Should handle CREATE_TOPIC_REQUEST', () => {
+    const topics = createTopics(20);
+    const newTopics = [...topics, data];
+    expect(
+      reducer({
+        topics
+      },
+      {
+        type: types.CREATE_TOPIC_REQUEST,
+        id: data.id,
+        count: data.count,
+        text: data.text
+
+      })
+    ).toEqual({
+        newTopic: '',
+        topics: newTopics
+    });
+  });
+
+  it('should handle CREATE_TOPIC_FAILURE', () => {
+    const topics = createTopics(20);
+    topics.push(data);
+    const newTopics = [...topics];
+    expect(
+      reducer({
+        topics,
+        newTopic: topic
+      },
+      {
+        type: types.CREATE_TOPIC_FAILURE,
+        id: data.id
+      })
+    ).toEqual({
+        topics: newTopics.pop() && newTopics,
+        newTopic: topic
+    });
+  });
+
+  it('should handle DESTROY_TOPIC', () => {
+    const topics = createTopics(20);
+    topics.push(data);
+    const newTopics = [...topics];
+    expect(
+      reducer({
+        topics,
+        newTopic: topic
+      },
+      {
+        type: types.DESTROY_TOPIC,
+        index: topics.length - 1
+      })
+    ).toEqual({
+        topics: newTopics.pop() && newTopics,
+        newTopic: topic
+    });
+  });
+
+  it('should handle INCREMENT_COUNT', () => {
+    const topics = createTopics(20);
+    const newTopics = [...topics];
+    topics.push(data);
+    const newData = Object.assign({}, data);
+    newData.count++;
+    newTopics.push(newData);
+
+    expect(
+      reducer({
+        topics,
+        newTopic: topic
+      },
+      {
+        type: types.INCREMENT_COUNT,
+        index: topics.length - 1,
+      })
+    ).toEqual({
+        topics: newTopics,
+        newTopic: topic
+    });
+  });
+
+  it('should handle DECREMENT_COUNT', () => {
+    const topics = createTopics(20);
+    const newTopics = [...topics];
+    topics.push(data);
+    const newData = Object.assign({}, data);
+    newData.count--;
+    newTopics.push(newData);
+
+    expect(
+      reducer({
+        topics,
+        newTopic: topic
+      },
+      {
+        type: types.DECREMENT_COUNT,
+        index: topics.length - 1
+      })
+    ).toEqual({
+        topics: newTopics,
+        newTopic: topic
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "bcrypt-nodejs": "0.0.3",
     "bluebird": "^3.3.5",
     "body-parser": "^1.15.0",
+    "chai": "^3.5.0",
     "classnames": "^2.2.3",
     "connect-mongo": "^1.1.0",
     "connect-pg-simple": "^3.1.0",


### PR DESCRIPTION
- Added async tests for increment, decrement, and destrory for both on success and on fail
- Added .catch for increment, decrement, and destroy
    - Dispatched 'createTopicFailure' as a placeholder
- Added reducer tests for all reducer cases
- Added 'error' key on state to manage error messages

Issue #241 