### PR TITLE
Fix mongoLabs URI Heroku environment var

### DIFF
--- a/server/db/mongo/constants.js
+++ b/server/db/mongo/constants.js
@@ -1,4 +1,4 @@
-export const db = process.env.MONGOHQ_URL || process.env.MONGOLAB_URI || 'mongodb://localhost/ReactWebpackNode';
+export const db = process.env.MONGOHQ_URL || process.env.MONGODB_URI || 'mongodb://localhost/ReactWebpackNode';
 
 export default {
   db


### PR DESCRIPTION
**tl;dr**
MongoLabs addons on Heroku wasn't working due to an incorrect URI supplied

**Read more**
https://devcenter.heroku.com/articles/mongolab#getting-your-connection-uri