### PR TITLE
Require webpack-dev config only in DEV mode

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,6 @@ import { connect } from './db';
 import passportConfig from './config/passport';
 import expressConfig from './config/express';
 import routesConfig from './config/routes';
-import webpackDevConfig from '../webpack/webpack.config.dev-client';
 const App = require('../public/assets/server');
 const app = express();
 
@@ -22,7 +21,7 @@ connect();
 passportConfig();
 
 if (ENV === 'development') {
-  const compiler = webpack(webpackDevConfig);
+  const compiler = webpack(require('../webpack/webpack.config.dev-client'));
   app.use(require('webpack-dev-middleware')(compiler, {
     noInfo: true,
     publicPath: webpackDevConfig.output.publicPath


### PR DESCRIPTION
Fixing [this](https://github.com/choonkending/react-webpack-node/blob/master/server/index.js#L8) line that should only be conditionally required.

```javascript
const compiler = webpack(webpackDevConfig);
```

This was causing heroku deployment failures when `webpack.config.dev-client` contained dependencies not installed in `npm install --production`